### PR TITLE
Implement variable toolbar order

### DIFF
--- a/crosswords/ViewModifiers/UITextField+Toolbar.swift
+++ b/crosswords/ViewModifiers/UITextField+Toolbar.swift
@@ -25,27 +25,45 @@ extension UITextField {
         return UIImage(systemName: "lifepreserver")!
     }
     
+    
     func changeToolbar(clueTitle: String, toggleImage: UIImage, barColor: UIColor) {
-        let uiTextFieldToolbar = self.inputAccessoryView as! UIToolbar
-        let clueTitleLabel = uiTextFieldToolbar.items![3].customView as! UITextView
+        
+        guard let uiTextFieldToolbar = self.inputAccessoryView as? UIToolbar else {
+            print("inputAccessoryView is nil or not a UIToolbar")
+            return
+        }
+
+        let clueTitleIndex = 3
+        let clueTitleLabel = uiTextFieldToolbar.items![clueTitleIndex].customView as! UITextView
+        
         if (uiTextFieldToolbar.backgroundColor != barColor) {
             uiTextFieldToolbar.backgroundColor = barColor
         }
         if (clueTitleLabel.text.trimmingCharacters(in: .whitespaces) != clueTitle.trimmingCharacters(in: .whitespaces)) {
-            uiTextFieldToolbar.items?.remove(at: 3)
+            uiTextFieldToolbar.items?.remove(at: clueTitleIndex)
             clueTitleLabel.text = clueTitle
-            uiTextFieldToolbar.items?.insert(UIBarButtonItem.init(customView: clueTitleLabel), at: 3)
+            uiTextFieldToolbar.items?.insert(UIBarButtonItem.init(customView: clueTitleLabel), at: clueTitleIndex)
         }
-        if (uiTextFieldToolbar.items![6].image != toggleImage) {
-            uiTextFieldToolbar.items![6].image = toggleImage
+        
+        var toggle =
+            switch UserDefaults.standard.integer(forKey: "clueCyclePlacement") {
+            case 1:
+                uiTextFieldToolbar.items![4]
+            case 2:
+                uiTextFieldToolbar.items![0]
+            default:
+                uiTextFieldToolbar.items![6]
+            }
+        
+        
+        if (toggle.image != toggleImage) {
+            toggle.image = toggleImage
         }
     }
     
     func addToolbar(coordinator: CrosswordTextFieldView.Coordinator, clueTitle: String, toggleImage: UIImage, barColor: UIColor) {
         self.inputAccessoryView = UIToolbar(frame: CGRect(x: 0.0, y: 0.0, width: Double(UIScreen.main.bounds.size.width), height: toolbarHeight))
-        
-        let flexible = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        
+                
         let clueTitleLabel = UITextView()
         var clueFontSize = UserDefaults.standard.integer(forKey: "clueSize")
         if (clueFontSize < 13) {
@@ -62,35 +80,48 @@ extension UITextField {
         clueTitleLabel.allowsEditingTextAttributes = false
         clueTitleLabel.isSelectable = false
         
-        
-        let clueTitle = UIBarButtonItem.init(customView: clueTitleLabel)
-        
-        
-        let leftButton = UIBarButtonItem()
-        leftButton.image = previousImage
-        leftButton.target = coordinator
-        leftButton.action = #selector(coordinator.goToPreviousClue)
-        
-        let rightButton = UIBarButtonItem()
-        rightButton.image = nextImage
-        rightButton.target = coordinator
-        rightButton.action = #selector(coordinator.goToNextClue)
-        
-        var solveCellButton = UIBarButtonItem()
-        if (coordinator.isSolutionAvailable(textField: self as! NoActionTextField)) {
-            solveCellButton.image = solveCellImage
-            solveCellButton.target = coordinator
-            solveCellButton.action = #selector(coordinator.solveCell)
-        } else {
-            solveCellButton = flexible
-        }
+        var configuredToolbarItems: [UIBarButtonItem] {
+            
+            let clueTitle = UIBarButtonItem(customView: clueTitleLabel)
+            
+            let flexible = UIBarButtonItem(barButtonSystemItem: .flexibleSpace,
+                                           target: nil,
+                                           action: nil)
 
-        let toggleButton = UIBarButtonItem()
-        toggleButton.image = toggleImage
-        toggleButton.target = coordinator
-        toggleButton.action = #selector(coordinator.pressToggleButton)
+            let leftButton = UIBarButtonItem(image: previousImage,
+                                             style: .plain,
+                                             target: coordinator,
+                                             action: #selector(coordinator.goToPreviousClue))
+            
+            let rightButton = UIBarButtonItem(image: nextImage,
+                                              style: .plain,
+                                              target: coordinator,
+                                              action: #selector(coordinator.goToNextClue))
+
+            let toggleButton = UIBarButtonItem(image: toggleImage,
+                                               style: .plain,
+                                               target: coordinator,
+                                               action: #selector(coordinator.pressToggleButton))
+
+            let solveCellButton: UIBarButtonItem = {
+                if coordinator.isSolutionAvailable(textField: self as! NoActionTextField) {
+                    return UIBarButtonItem(image: solveCellImage, style: .plain, target: coordinator, action: #selector(coordinator.solveCell))
+                } else {
+                    return flexible
+                }
+            }()
+            
+            switch UserDefaults.standard.integer(forKey: "clueCyclePlacement") {
+            case 1:
+                return [leftButton, flexible, solveCellButton, clueTitle, toggleButton, flexible, rightButton]
+            case 2:
+                return [toggleButton, solveCellButton, flexible, clueTitle, flexible, leftButton, rightButton]
+            default:
+                return [leftButton, rightButton, flexible, clueTitle, flexible, solveCellButton, toggleButton]
+            }
+        }
         
-        (self.inputAccessoryView as! UIToolbar).setItems([leftButton, rightButton, flexible, clueTitle, flexible, solveCellButton, toggleButton], animated: false)
+        (self.inputAccessoryView as! UIToolbar).setItems(configuredToolbarItems, animated: false)
         
         (self.inputAccessoryView as! UIToolbar).backgroundColor = barColor
     }

--- a/crosswords/Views/SettingsView.swift
+++ b/crosswords/Views/SettingsView.swift
@@ -142,7 +142,18 @@ struct PickerViews: View {
                 ColorSchemeUtil().overrideDisplayMode()
             })
             .pickerStyle(.segmented)
-
+            
+            HStack {
+                Text("Clue cycle control placement:")
+                Spacer()
+                Picker("Keyboard Toolbar Style", selection: $userSettings.clueCyclePlacement) {
+                    Text("Left").tag(0)
+                    Text("Split").tag(1)
+                    Text("Right").tag(2)
+                }
+                .pickerStyle(.menu)
+            }
+            
             HStack {
                 Text("Automatically delete puzzles after:")
                 Spacer()
@@ -295,6 +306,12 @@ class UserSettings: ObservableObject {
             UserDefaults.standard.set(useEmailAddressKeyboard, forKey: "useEmailAddressKeyboard")
         }
     }
+    
+    @Published var clueCyclePlacement: Int {
+        didSet {
+            UserDefaults.standard.set(clueCyclePlacement, forKey: "clueCyclePlacement")
+        }
+    }
 
     @Published var user: User?
     @Published var gameCenterPlayer: GKLocalPlayer?
@@ -327,6 +344,7 @@ class UserSettings: ObservableObject {
         self.clueSize = UserDefaults.standard.object(forKey: "clueSize") as? Int ?? 13
         self.largePrintMode = UserDefaults.standard.bool(forKey: "largePrintMode")
         self.useEmailAddressKeyboard = UserDefaults.standard.bool(forKey: "useEmailAddressKeyboard")
+        self.clueCyclePlacement = UserDefaults.standard.object(forKey: "clueCyclePlacement") as? Int ?? 0
         self.gameCenterPlayer?.register(GameCenterListener())
     }
 }


### PR DESCRIPTION
**Purpose:** The default toolbar layout (the ribbon above the keyboard with the clue, clue cycle buttons, etc...) is not very ergonomic, especially for right handed users. By allowing users to pick from a left, right, and split layout for the cycle buttons, which are the most important buttons on the screen, everyone can have a more accessible experience.

**Changes:**

*Views/SettingsView.swift*
- Add user setting "clueCyclePlacement" to store selected arrangement of toolbar
  - 0: Cycle buttons on the left
  - 1: Back button on left, next button on right
  - 2: Cycle buttons on right
- Add Picker to settings to allow selecting clue cycle placement

*ViewModifiers/UITextField+Toolbar.swift*
- Add switch to select between 3 different layout arrays

Settings:
<img width="406" height="874" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-11 at 16 57 11" src="https://github.com/user-attachments/assets/76f51081-2a8b-42e1-bf5e-a45a34357b04" />

Left (current layout):
<img width="406" height="874" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-11 at 16 57 36" src="https://github.com/user-attachments/assets/fe276a7d-e4f0-44c6-b308-76a61c74f9f5" />

Split:
<img width="406" height="874" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-11 at 16 57 56" src="https://github.com/user-attachments/assets/a370bfde-690d-4b74-b549-1a65a2bf5754" />

Right:
<img width="406" height="874" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-11 at 16 58 12" src="https://github.com/user-attachments/assets/2861373d-04e5-43c6-86a9-c8b18a7b595a" />

